### PR TITLE
Fix missing contentHash if method is not uppercase

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -46,7 +46,7 @@ module.exports = {
     logger.info('Body is \"' + preparedBody + '\"');
     logger.debug('PREPARED BODY LENGTH', preparedBody.length);
 
-    if (request.method === 'POST' && preparedBody.length > 0) {
+    if (request.method.toUpperCase() === 'POST' && preparedBody.length > 0) {
       logger.info('Signing content: \"' + preparedBody + '\"');
 
       // If body data is too large, cut down to max-body size


### PR DESCRIPTION
I've called the auth method with a lowercase "post" method property. This led to a "The signature does not match" error response. Afters hours of debugging I noticed that the contentHash was missing. This PR should fix this kind of errors.