### PR TITLE
[Debug] Added require for logger

### DIFF
--- a/src/edgerc.js
+++ b/src/edgerc.js
@@ -12,7 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-var fs = require('fs');
+var fs = require('fs'),
+  logger = require('./logger');
 
 function getSection(lines, sectionName) {
   var match = /^\s*\[(.*)\]/


### PR DESCRIPTION
@dshafik while working on #33 I noticed this small issue. The `edgerc.js` code uses an undefined variable called `logger` in exactly one line, whereas the variable is set to a local `require` everywhere else it is used. I just fixed that but I didn't think bundling with the other fixes was appropriate.

Can you review? Thanks!