### PR TITLE
[#33] handle 413 error

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -68,8 +68,7 @@ EdgeGrid.prototype.auth = function(req) {
 };
 
 EdgeGrid.prototype.send = function(callback) {
-  request(this.request, function(error, response, body) { 
-    
+  request(this.request, function(error, response, body) {
     if (error) {
       callback(error);
       return;
@@ -78,8 +77,9 @@ EdgeGrid.prototype.send = function(callback) {
       this._handleRedirect(response, callback);
       return;
     }
-
-    callback(null, response, body);
+    // process response to make sure body is JSON
+    response = helpers.normalizeResponse(response);
+    callback(null, response, response.body);
   }.bind(this));
 
   return this;

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -102,6 +102,26 @@ module.exports = {
     ].indexOf(statusCode) !== -1;
   },
 
+  normalizeResponse: function(response) {
+    try {
+      // This will fail on an invalid JSON string
+      JSON.parse(response.body)
+    } catch (e) {
+      response.body = JSON.stringify({
+        supportId: "",
+        title: response.statusMessage,
+        httpStatus: response.statusCode,
+        detail: "",
+        describedBy: ""
+      });
+      response.headers["content-length"] = response.body.length;
+      response.headers["content-type"] = "application/api-problem+json";
+      response.rawHeaders[response.rawHeaders.indexOf("Content-Length") + 1] = response.headers["content-length"];
+      response.rawHeaders[response.rawHeaders.indexOf("Content-Type") + 1] = response.headers["content-type"];
+    }
+    return response;
+  },
+
   base64Sha256: function(data) {
     var shasum = crypto.createHash('sha256').update(data);
 

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -109,8 +109,8 @@ module.exports = {
     } catch (e) {
       response.body = JSON.stringify({
         supportId: "",
-        title: response.statusMessage,
-        httpStatus: response.statusCode,
+        title: response.statusMessage || "",
+        httpStatus: response.statusCode || 0,
         detail: "",
         describedBy: ""
       });

--- a/test/src/api_test.js
+++ b/test/src/api_test.js
@@ -297,5 +297,32 @@ describe('Api', function() {
         });
       });
     });
+    describe('when the server responds with HTML', function() {
+      it('transforms the response into JSON with code and message', function(done) {
+        var body = '<!DOCTYPE HTML PUBLIC "-//IETF//DTD HTML 2.0//EN">'
+          + '<html><head>'
+          + '<title>413 Request Entity Too Large</title>'
+          + '</head><body>'
+          + '<h1>Request Entity Too Large</h1>'
+          + 'The requested resource<br />/restccu.wsgi/ccuopen/v3/invalidate/url/staging<br />'
+          + 'does not allow request data with POST requests, or the amount of data provided in'
+          + 'the request exceeds the capacity limit.'
+          + '</body></html>';
+        nock('https://base.com')
+          .post('/foo')
+          .reply(413, body);
+
+        this.api.auth({
+          path: '/foo',
+          method: 'POST'
+        });
+
+        this.api.send(function(error, response, data) {
+          var data = JSON.parse(data);
+          assert.equal(data.httpStatus, 413);
+          done();
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This solves #33 by processing API responses and making sure they are JSON. When an HTML response is encountered, the code builds a standard response and populates the `title` and `httpStatus` with the appropriate values, leaving everything else empty.

@dshafik can you review? Thanks!