### PR TITLE
Update log4js dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "log4js": "^0.6.14",
+    "log4js": "^2.5.3",
     "moment": "^2.7.0",
     "request": "2.83.0",
     "uuid": "^3.0.0"

--- a/src/logger.js
+++ b/src/logger.js
@@ -15,8 +15,6 @@
 var log4js = require('log4js'),
     logger = log4js.getLogger();
 
-if (!process.env.LOG4JS_CONFIG) {
-  logger.setLevel(log4js.levels.ERROR);
-}
+logger.level = process.env.LOG4JS_CONFIG || 'error';
 
 module.exports = logger;


### PR DESCRIPTION
Updates the log4js dependency from 0.6.14 (circa 2014) to most recent (2.5.3), which resolves issues using edgegrid with webpack.