### PR TITLE
Add jsesc library in order to escape unicode characters from request body

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "log4js": "^0.6.14",
     "moment": "^2.22.2",
     "request": "^2.88.0",
-    "uuid": "^3.0.0"
+    "uuid": "^3.0.0",
+    "jsesc": "^2.5.2"
   },
   "devDependencies": {
     "mocha": "^5.2.0",

--- a/src/api.js
+++ b/src/api.js
@@ -14,6 +14,7 @@
 
 var request = require('request'),
   url = require('url'),
+  jsesc = require('jsesc'),
   auth = require('./auth'),
   edgerc = require('./edgerc'),
   helpers = require('./helpers'),
@@ -62,6 +63,7 @@ EdgeGrid.prototype.auth = function(req) {
     if (typeof(req.body) == 'object') {
       req.body = JSON.stringify(req.body);
     }
+    req.body = jsesc(req.body);
   }
 
   this.request = auth.generateAuth(


### PR DESCRIPTION
In reference to #52 

See the two files attached for tests. They are used as body for requests to Cloudlet Edge Redirector API. Without escaping unicode characters, signature is wrong on body.txt because truncation of the file does not happen properly.
It works properly with or without escaping when truncation is not performed.

[body.txt](https://github.com/akamai/AkamaiOPEN-edgegrid-node/files/3112501/body.txt)
[reduced_body.txt](https://github.com/akamai/AkamaiOPEN-edgegrid-node/files/3112502/reduced_body.txt)

