### PR TITLE
Updates log4js Version

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EdgeGrid for Node.js
 
-[This verions of EdgeGrid for Node.js has updated log4js version from 0.6.14 to 1.0.0 to fix issues with SemVer plugin for webpack (see https://github.com/log4js-node/log4js-node/issues/391 fro more details)].
+#### This verions of EdgeGrid for Node.js has updated log4js version from 0.6.14 to 1.0.0 to fix issues with SemVer plugin for webpack (see https://github.com/log4js-node/log4js-node/issues/391 fro more details).
 
 [![Build Status](https://travis-ci.org/akamai/AkamaiOPEN-edgegrid-node.svg?branch=master)](https://travis-ci.org/akamai/AkamaiOPEN-edgegrid-node)
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # EdgeGrid for Node.js
 
+[This verions of EdgeGrid for Node.js has updated log4js version from 0.6.14 to 1.0.0 to fix issues with SemVer plugin for webpack (see https://github.com/log4js-node/log4js-node/issues/391 fro more details)].
+
 [![Build Status](https://travis-ci.org/akamai/AkamaiOPEN-edgegrid-node.svg?branch=master)](https://travis-ci.org/akamai/AkamaiOPEN-edgegrid-node)
 
 This library implements an Authentication handler for the [Akamai OPEN](hhttps://developer.akamai.com/introduction/) EdgeGrid Authentication scheme in Node.js For more infomation visit the [Akamai {OPEN} Developer Portal](https://developer.akamai.com/).

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ This library implements an Authentication handler for the [Akamai OPEN](hhttps:/
 
 ## Installation
 
-`npm install --save edgegrid`
+`npm install --save edgegrid-update-log4js`
 
 ## Example
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # EdgeGrid for Node.js
 
-#### This verions of EdgeGrid for Node.js has updated log4js version from 0.6.14 to 1.0.0 to fix issues with SemVer plugin for webpack (see https://github.com/log4js-node/log4js-node/issues/391 fro more details).
+#### This version of EdgeGrid for Node.js has updated log4js version from 0.6.14 to 1.0.0 to fix issues with SemVer plugin for webpack (see https://github.com/log4js-node/log4js-node/issues/391 fro more details) and you can get it in https://www.npmjs.com/package/edgegrid-update-log4js.
 
 [![Build Status](https://travis-ci.org/akamai/AkamaiOPEN-edgegrid-node.svg?branch=master)](https://travis-ci.org/akamai/AkamaiOPEN-edgegrid-node)
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "license": "Apache-2.0",
   "dependencies": {
-    "log4js": "^0.6.14",
+    "log4js": "^1.0.0",
     "moment": "^2.22.2",
     "request": "^2.88.0",
     "uuid": "^3.0.0"


### PR DESCRIPTION
Updates log4js version from 0.6.14 to 1.0.0 to fix issues with SemVer plugin for webpack (see https://github.com/log4js-node/log4js-node/issues/391 fro more details).