### PR TITLE
Enable GitHub Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+# See https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"


### PR DESCRIPTION
This library requires several outdated/old dependencies [1][2].  This pull request enables [GitHub's Dependabot ](https://docs.github.com/en/code-security/supply-chain-security/keeping-your-dependencies-updated-automatically) in order to have pull requests automatically opened when there are dependency updates.

As an example for what this pull request will enable, I created a non-fork copy of this repo _(which will be deleted after this PR is merged)_ and enabled Depandabot to illustrate what the pull requests will look like: https://github.com/siwinski/AkamaiOPEN-edgegrid-node--with-dependabot/pulls

You may also want to enable [Dependabot security updates](https://docs.github.com/en/code-security/supply-chain-security/managing-vulnerabilities-in-your-projects-dependencies/configuring-dependabot-security-updates) (repo settings)

[1]
```
$ npx npm-check-updates 
[...]
[====================] 6/6 100%

 axios   ^0.21.4  →  ^0.24.0     
 log4js  ^0.6.14  →   ^6.3.0     
 moment  ^2.22.2  →  ^2.29.1     
 uuid     ^3.0.0  →   ^8.3.2     
 mocha    ^9.0.1  →   ^9.1.3     
 nock    ^10.0.1  →  ^13.2.1     

Run ncu -u to upgrade package.json
```

[2] https://github.com/akamai/AkamaiOPEN-edgegrid-node/pull/61