### PR TITLE
Enable CI tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,22 @@
+name: Test
+
+on:
+  - push
+  - pull_request
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node: [12, 14, 16]
+    name: Test Node ${{ matrix.node }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: Setup node
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm install
+      - run: npm run build --if-present
+      - run: npm test


### PR DESCRIPTION
This pull request enables [GitHub Actions](https://docs.github.com/en/actions) CI to test all pushes and pull requests.  The [`package.json`](https://github.com/akamai/AkamaiOPEN-edgegrid-node/blob/master/package.json) file does not specify [`engines`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#engines) so I set up tests to run for [all current Node LTS versions](https://nodejs.org/en/about/releases/) (i.e. 12, 14, and 16).

Example run from my fork: https://github.com/siwinski/AkamaiOPEN-edgegrid-node/actions/runs/1672286989

This pull request would pair nicely with the ["Enable GitHub Dependabot" pull request](https://github.com/akamai/AkamaiOPEN-edgegrid-node/pull/72) to automatically run tests for all dependency update pull requests