### PR TITLE
Remove moment dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "axios": "^0.26.0",
         "log4js": "^6.4.0",
-        "moment": "^2.29.1",
         "uuid": "^8.3.2"
       },
       "devDependencies": {
@@ -818,14 +817,6 @@
       "dev": true,
       "engines": {
         "node": ">=10"
-      }
-    },
-    "node_modules/moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/ms": {
@@ -1720,11 +1711,6 @@
           "dev": true
         }
       }
-    },
-    "moment": {
-      "version": "2.29.1",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
-      "integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ=="
     },
     "ms": {
       "version": "2.1.3",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "axios": "^0.26.0",
     "log4js": "^6.4.0",
-    "moment": "^2.29.1",
     "uuid": "^8.3.2"
   },
   "devDependencies": {

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -13,14 +13,32 @@
 // limitations under the License.
 
 const crypto = require('crypto'),
-    moment = require('moment'),
     logger = require('./logger'),
     path = require('path'),
     os = require('os');
 
+function twoDigitNumberPad(number) {
+    return String(number).padStart(2, '0');
+}
+
 module.exports = {
+    /**
+     * Create timestamp with format "yyyyMMddTHH:mm:ss+0000"
+     *
+     * @see https://developer.akamai.com/legacy/introduction/Client_Auth.html#authorizationheaderfields
+     */
     createTimestamp: function () {
-        return moment().utc().format('YYYYMMDDTHH:mm:ss+0000');
+        const date = new Date(Date.now());
+
+        return date.getUTCFullYear() +
+            twoDigitNumberPad(date.getUTCMonth() + 1) +
+            twoDigitNumberPad(date.getUTCDate()) +
+            'T' +
+            twoDigitNumberPad(date.getUTCHours()) + ':' +
+            twoDigitNumberPad(date.getUTCMinutes()) +
+            ':' +
+            twoDigitNumberPad(date.getUTCSeconds()) +
+            '+0000';
     },
 
     contentHash: function (request, maxBody) {


### PR DESCRIPTION
From [`moment`'s README](https://www.npmjs.com/package/moment#project-status):
> Moment.js is a legacy project, now in maintenance mode. In most cases, you should choose a different library.
> 
> For more details and recommendations, please see [Project Status](https://momentjs.com/docs/#/-project-status/) in the docs.

This pull request removes the [`moment`](https://www.npmjs.com/package/moment) dependency and replaces its usage with JavaScript build-in logic.

To illustrate passing test suite runs, here is a GitHub Actions run from a branch that merges these changes with https://github.com/akamai/AkamaiOPEN-edgegrid-node/pull/73 ("Enable CI tests") in my fork of this repo: https://github.com/siwinski/AkamaiOPEN-edgegrid-node/actions/runs/1672622378

I also wrote a quick comparison script that shows the values are the same and that the built-in logic is faster:

Output:
```
Return values:
  moment: 20220109T00:49:49+0000
built-in: 20220109T00:49:49+0000

Benchmarks:
moment x 344,288 ops/sec ±0.69% (92 runs sampled)
built-in x 1,711,373 ops/sec ±0.62% (92 runs sampled)
Fastest is *****built-in*****
```

Script:
```js
const moment = require('moment');

function createTimestampMoment() {
    return moment().utc().format('YYYYMMDDTHH:mm:ss+0000');
}

// ----------------------------------------------------------------------------

function twoDigitNumberPad(number) {
    return String(number).padStart(2, '0');
}

function createTimestampBuiltIn() {
    const date = new Date(Date.now());

    return date.getUTCFullYear() +
        twoDigitNumberPad(date.getUTCMonth() + 1) +
        twoDigitNumberPad(date.getUTCDate()) +
        'T' +
        twoDigitNumberPad(date.getUTCHours()) + ':' +
        twoDigitNumberPad(date.getUTCMinutes()) +
        ':' +
        twoDigitNumberPad(date.getUTCSeconds()) +
        '+0000';
}

// ----------------------------------------------------------------------------

console.log('Return values:');
console.log('  moment:', createTimestampMoment());
console.log('built-in:', createTimestampBuiltIn());

// ----------------------------------------------------------------------------

const Benchmark = require('benchmark');

console.log('');
console.log('Benchmarks:');

const suite = new Benchmark.Suite;
suite
    .add('moment', createTimestampMoment)
    .add('built-in', createTimestampBuiltIn)
    .on('cycle', function (event) {
        console.log(String(event.target));
    })
    .on('complete', function() {
        console.log('Fastest is *****' + this.filter('fastest').map('name') + '*****');
    })
    .run();
```

