### PR TITLE
Release/v3.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # RELEASE NOTES
 
+## 3.1.4 (Mar 24, 2022)
+
+#### IMPROVEMENTS:
+* Remove deprecated `moment` dependency
+
+#### BUG FIXES
+* Fix response when Content-Type is `application/gzip` ([#83](https://github.com/akamai/AkamaiOPEN-edgegrid-node/issues/83))
+
 ## 3.1.3 (Feb 22, 2022)
 
 #### IMPROVEMENTS:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "akamai-edgegrid",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "akamai-edgegrid",
-      "version": "3.1.3",
+      "version": "3.1.4",
       "license": "Apache-2.0",
       "dependencies": {
         "axios": "^0.26.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "akamai-edgegrid",
-  "version": "3.1.3",
+  "version": "3.1.4",
   "description": "Authentication handler for the Akamai OPEN EdgeGrid Authentication scheme in Node.js",
   "main": "index.js",
   "scripts": {

--- a/src/api.js
+++ b/src/api.js
@@ -84,6 +84,9 @@ EdgeGrid.prototype.auth = function (req) {
         this.config.access_token,
         this.config.host
     );
+    if (req.headers['Accept'] === 'application/gzip') {
+        this.request["responseType"] = 'arraybuffer';
+    }
     return this;
 };
 

--- a/test/src/api_test.js
+++ b/test/src/api_test.js
@@ -221,6 +221,33 @@ describe('Api', function () {
                 assert.strictEqual(this.api.request.somethingArbitrary, 'someValue');
             });
         });
+
+        describe("when gzip response format is expected", function () {
+            beforeEach(function () {
+                this.api.auth({
+                    path: '/foo',
+                    headers: {
+                        'Accept': `application/gzip`
+                    }
+                });
+            });
+
+            it('adds an Authorization header to the request it is passed', function () {
+                assert.strictEqual(typeof this.api.request.headers.Authorization === 'string', true);
+            });
+
+            it('ensures a default GET method', function () {
+                assert.strictEqual(this.api.request.method, 'GET');
+            });
+
+            it('ensures a default empty body', function () {
+                assert.strictEqual(this.api.request.body, '');
+            });
+
+            it('should return response as buffer', function () {
+                assert.strictEqual(this.api.request["responseType"], "arraybuffer");
+            });
+        });
     });
 
     describe('#send', function () {


### PR DESCRIPTION
# RELEASE NOTES

## 3.1.4 (Mar 24, 2022)

#### IMPROVEMENTS:
* Remove deprecated `moment` dependency

#### BUG FIXES
* Fix response when Content-Type is `application/gzip` ([#83](https://github.com/akamai/AkamaiOPEN-edgegrid-node/issues/83))
