### PR TITLE
DXE-2682 Removing empty body default

### DIFF
--- a/src/api.js
+++ b/src/api.js
@@ -53,8 +53,7 @@ EdgeGrid.prototype.auth = function (req) {
         url: req.path,
         method: 'GET',
         headers: {},
-        maxRedirects: 0,
-        body: ''
+        maxRedirects: 0
     });
 
     req.headers = helpers.extendHeaders(req.headers);

--- a/test/src/api_test.js
+++ b/test/src/api_test.js
@@ -280,8 +280,8 @@ describe('Api', function () {
                 assert.strictEqual(this.api.request.method, 'GET');
             });
 
-            it('ensures a default empty body', function () {
-                assert.strictEqual(this.api.request.body, '');
+            it('ensures a default undefined body', function () {
+                assert.strictEqual(this.api.request.body, undefined);
             });
 
             it('ensures a url is properly declared', function () {


### PR DESCRIPTION
The current behaviour adds an empty string as the body for all requests where the body is not specified. On zero length POSTs (e.g. https://techdocs.akamai.com/iam-api/reference/post-client-credentials-deactivate) this breaks the EdgeGrid auth calculation.