### PR TITLE
Removed Node.js version 12 check from tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node: [12, 14, 16, 18, 20, 21]
+        node: [14, 16, 18, 20, 21]
     name: Test Node ${{ matrix.node }}
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Removed Node.js 12 check from tests as it reached End-of-Life on April 30, 2022.
