### PR TITLE
Add support for custom Axios instance in EdgeGrid

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,6 +224,53 @@ Enable debugging to get additional information about a request. You can configur
   $ node src/main.js
   ```
 
+### Custom Axios Instance
+
+You can inject a custom axios instance to use instead of the default one. This allows you to configure custom timeouts, interceptors, or other axios-specific features.
+
+#### Using string parameters:
+
+```javascript
+const axios = require('axios');
+
+// Create a custom axios instance
+const customAxios = axios.create({
+    timeout: 30000, // 30 second timeout
+    headers: {
+        'User-Agent': 'MyCustomApp/1.0'
+    }
+});
+
+// Add custom interceptors
+customAxios.interceptors.request.use(config => {
+    console.log('Making request to:', config.url);
+    return config;
+});
+
+// Use with EdgeGrid
+var eg = new EdgeGrid(
+    'your-client-token',
+    'your-client-secret', 
+    'your-access-token',
+    'your-host.luna.akamaiapis.net',
+    false, // debug
+    undefined, // max_body
+    customAxios // custom axios instance
+);
+```
+
+#### Using object configuration:
+
+```javascript
+var eg = new EdgeGrid({
+    path: '/path/to/.edgerc',
+    section: 'section-header',
+    axiosInstance: customAxios
+});
+```
+
+If no custom axios instance is provided, the library will use the default axios instance.
+
 
 
 ## Reporting issues

--- a/examples/custom-axios-instance.js
+++ b/examples/custom-axios-instance.js
@@ -1,0 +1,70 @@
+// This example demonstrates how to use a custom axios instance with EdgeGrid.
+//
+// To run this example:
+//
+// 1. Make sure you have a valid `.edgerc` file with your credentials.
+//
+// 2. Open a Terminal or shell instance and run "node examples/custom-axios-instance.js".
+//
+// This example shows how to inject a custom axios instance with custom configuration
+// like timeout settings, interceptors, or other axios-specific features.
+
+const EdgeGrid = require('akamai-edgegrid');
+const axios = require('axios');
+
+// Create a custom axios instance with specific configuration
+const customAxios = axios.create({
+    timeout: 30000, // 30 second timeout
+    headers: {
+        'User-Agent': 'MyCustomApp/1.0'
+    }
+});
+
+// Add custom interceptors to the axios instance
+customAxios.interceptors.request.use(config => {
+    console.log('Custom axios instance making request to:', config.url);
+    return config;
+});
+
+customAxios.interceptors.response.use(response => {
+    console.log('Custom axios instance received response:', response.status);
+    return response;
+});
+
+// Method 1: Using string parameters with custom axios instance
+console.log('=== Method 1: String parameters with custom axios ===');
+const eg1 = new EdgeGrid(
+    'your-client-token',
+    'your-client-secret', 
+    'your-access-token',
+    'your-host.luna.akamaiapis.net',
+    false, // debug
+    undefined, // max_body
+    customAxios // custom axios instance
+);
+
+// Method 2: Using object configuration with custom axios instance
+console.log('=== Method 2: Object configuration with custom axios ===');
+const eg2 = new EdgeGrid({
+    path: '~/.edgerc',
+    section: 'default',
+    axiosInstance: customAxios
+});
+
+// Example API call using the custom axios instance
+eg1.auth({
+    path: '/identity-management/v3/api-clients/self/credentials',
+    method: 'GET',
+    headers: {
+        'Accept': "application/json"
+    }
+});
+
+eg1.send(function(error, response, body) {
+    if (error) {
+        console.log('Error:', error.message);
+    } else {
+        console.log('Response status:', response.status);
+        console.log('Response body:', body);
+    }
+}); 

--- a/test/src/axios_instance_test.js
+++ b/test/src/axios_instance_test.js
@@ -1,0 +1,213 @@
+const assert = require("assert"),
+    EdgeGrid = require('../../src/api.js'),
+    axios = require('axios'),
+    nock = require('nock');
+
+describe('Axios Instance Injection', function () {
+    const testConfig = {
+        client_token: "akab-client-token-xxx-xxxxxxxxxxxxxxxx",
+        client_secret: "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx=",
+        access_token: "akab-access-token-xxx-xxxxxxxxxxxxxxxx",
+        host: "https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net/"
+    };
+
+    beforeEach(function() {
+        nock.cleanAll();
+    });
+
+    afterEach(function() {
+        nock.cleanAll();
+    });
+
+    describe('Custom axios instance injection', function () {
+        it('should use custom axios instance when provided via string parameters', function () {
+            const customAxios = axios.create();
+            const eg = new EdgeGrid(
+                testConfig.client_token,
+                testConfig.client_secret,
+                testConfig.access_token,
+                testConfig.host,
+                false, // debug
+                undefined, // max_body
+                customAxios // axiosInstance
+            );
+            assert.strictEqual(eg.axiosInstance, customAxios);
+            assert.notStrictEqual(eg.axiosInstance, axios);
+        });
+        it('should use default axios instance when no custom instance provided via string parameters', function () {
+            const eg = new EdgeGrid(
+                testConfig.client_token,
+                testConfig.client_secret,
+                testConfig.access_token,
+                testConfig.host
+            );
+            assert.strictEqual(eg.axiosInstance, axios);
+        });
+    });
+
+    describe('Custom axios instance functionality', function () {
+        it('should use custom axios instance for making requests', function (done) {
+            this.timeout(5000);
+            let customAxiosCalled = false;
+            const realAxiosInstance = axios.create();
+            // Create a proxy to wrap the axios instance and detect calls
+            const customAxios = new Proxy(realAxiosInstance, {
+                apply(target, thisArg, argumentsList) {
+                    customAxiosCalled = true;
+                    return Reflect.apply(target, thisArg, argumentsList);
+                }
+            });
+            nock('https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net')
+                .get('/test-endpoint')
+                .reply(200, { success: true });
+            const eg = new EdgeGrid(
+                testConfig.client_token,
+                testConfig.client_secret,
+                testConfig.access_token,
+                testConfig.host,
+                false,
+                undefined,
+                customAxios
+            );
+            eg.auth({
+                path: '/test-endpoint',
+                method: 'GET',
+                headers: {
+                    'Accept': "application/json"
+                }
+            });
+            eg.send(function(error, response, body) {
+                assert.strictEqual(customAxiosCalled, true);
+                assert.strictEqual(error, null);
+                done();
+            });
+        });
+        it('should use custom axios instance with custom configuration', function (done) {
+            const customAxios = axios.create({
+                timeout: 5000,
+                headers: {
+                    'X-Custom-Header': 'test-value'
+                }
+            });
+            let customHeadersSent = false;
+            nock('https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net')
+                .get('/test-endpoint')
+                .reply(function(uri, requestBody) {
+                    if (this.req.headers['x-custom-header'] === 'test-value') {
+                        customHeadersSent = true;
+                    }
+                    return [200, { success: true }];
+                });
+            const eg = new EdgeGrid(
+                testConfig.client_token,
+                testConfig.client_secret,
+                testConfig.access_token,
+                testConfig.host,
+                false,
+                undefined,
+                customAxios
+            );
+            eg.auth({
+                path: '/test-endpoint',
+                method: 'GET',
+                headers: {
+                    'Accept': "application/json"
+                }
+            });
+            eg.send(function(error, response, body) {
+                assert.strictEqual(customHeadersSent, true);
+                assert.strictEqual(error, null);
+                done();
+            });
+        });
+        it('should use custom axios instance with interceptors', function (done) {
+            const customAxios = axios.create();
+            let interceptorCalled = false;
+            customAxios.interceptors.request.use(function(config) {
+                interceptorCalled = true;
+                config.headers['X-Interceptor-Test'] = 'interceptor-value';
+                return config;
+            });
+            nock('https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net')
+                .get('/test-endpoint')
+                .reply(function(uri, requestBody) {
+                    if (this.req.headers['x-interceptor-test'] === 'interceptor-value') {
+                        return [200, { success: true }];
+                    }
+                    return [400, { error: 'Interceptor header not found' }];
+                });
+            const eg = new EdgeGrid(
+                testConfig.client_token,
+                testConfig.client_secret,
+                testConfig.access_token,
+                testConfig.host,
+                false,
+                undefined,
+                customAxios
+            );
+            eg.auth({
+                path: '/test-endpoint',
+                method: 'GET',
+                headers: {
+                    'Accept': "application/json"
+                }
+            });
+            eg.send(function(error, response, body) {
+                assert.strictEqual(interceptorCalled, true);
+                assert.strictEqual(error, null);
+                assert.strictEqual(response.status, 200);
+                done();
+            });
+        });
+        it('should handle errors from custom axios instance', function (done) {
+            const customAxios = axios.create();
+            nock('https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net')
+                .get('/test-endpoint')
+                .replyWithError('Network Error');
+            const eg = new EdgeGrid(
+                testConfig.client_token,
+                testConfig.client_secret,
+                testConfig.access_token,
+                testConfig.host,
+                false,
+                undefined,
+                customAxios
+            );
+            eg.auth({
+                path: '/test-endpoint',
+                method: 'GET',
+                headers: {
+                    'Accept': "application/json"
+                }
+            });
+            eg.send(function(error, response, body) {
+                assert.notStrictEqual(error, null);
+                assert.strictEqual(error.message, 'Network Error');
+                done();
+            });
+        });
+        it('should maintain backward compatibility with default axios', function (done) {
+            nock('https://akaa-baseurl-xxxxxxxxxxx-xxxxxxxxxxxxx.luna.akamaiapis.net')
+                .get('/test-endpoint')
+                .reply(200, { success: true });
+            const eg = new EdgeGrid(
+                testConfig.client_token,
+                testConfig.client_secret,
+                testConfig.access_token,
+                testConfig.host
+            );
+            eg.auth({
+                path: '/test-endpoint',
+                method: 'GET',
+                headers: {
+                    'Accept': "application/json"
+                }
+            });
+            eg.send(function(error, response, body) {
+                assert.strictEqual(error, null);
+                assert.strictEqual(response.status, 200);
+                done();
+            });
+        });
+    });
+}); 


### PR DESCRIPTION
- Updated README.md to include instructions for using a custom Axios instance.
- Modified EdgeGrid constructor to accept either a client token or an object with configuration options, including a custom Axios instance.
- Adjusted request and response interceptors to utilize the provided Axios instance if available.